### PR TITLE
Update setup.py, exclude 'tests'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/exxamalte/python-georss-ign-sismologia-client",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
otherwise it would try to install it on top level:

```
>>> Emerging (1 of 1) dev-python/georss-ign-sismologia-client-0.3::HomeAssistantRepository
>>> Failed to emerge dev-python/georss-ign-sismologia-client-0.3, Log file:
>>>  '/var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.44, 0.32, 0.33
 * Package:    dev-python/georss-ign-sismologia-client-0.3
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   coding@subspace.de
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking georss-ign-sismologia-client-0.3.tar.gz to /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work
>>> Source unpacked in /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work
>>> Preparing source in /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
running build
running build_py
creating /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3-python3_9/lib/tests
copying tests/__init__.py -> /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3-python3_9/lib/tests
copying tests/test_init.py -> /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3-python3_9/lib/tests
creating /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3-python3_9/lib/georss_ign_sismologia_client
copying georss_ign_sismologia_client/__init__.py -> /var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3-python3_9/lib/georss_ign_sismologia_client
...
running install_scripts
 * ERROR: dev-python/georss-ign-sismologia-client-0.3::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_install
 *   environment, line 2843:  Called distutils-r1_src_install
 *   environment, line 1180:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  451:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2518:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2049:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 2047:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line  765:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1148:  Called distutils-r1_python_install
 *   environment, line 1051:  Called die
 * The specific snippet of code:
 *               die "Package installs '${p}' package which is forbidden and likely a bug in the build system.";
 *
 * If you need support, post the output of `emerge --info '=dev-python/georss-ign-sismologia-client-0.3::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/georss-ign-sismologia-client-0.3::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3'
 * S: '/var/tmp/portage/dev-python/georss-ign-sismologia-client-0.3/work/georss_ign_sismologia_client-0.3'

 * Messages for package dev-python/georss-ign-sismologia-client-0.3:

 * ERROR: dev-python/georss-ign-sismologia-client-0.3::HomeAssistantRepository failed (install phase):
 *   Package installs 'tests' package which is forbidden and likely a bug in the build system.

```