### PR TITLE
Fixed wrong parser date order

### DIFF
--- a/georss_ign_sismologia_client/__init__.py
+++ b/georss_ign_sismologia_client/__init__.py
@@ -110,7 +110,7 @@ class IgnSismologiaFeedEntry(FeedEntry):
         """Return the published date of this entry."""
         published_date = self._search_in_title(REGEXP_ATTR_PUBLISHED_DATE)
         if published_date:
-            published_date = dateparser.parse(published_date)
+            published_date = dateparser.parse(published_date, settings={'DATE_ORDER': 'DMY', 'PREFER_LOCALE_DATE_ORDER': False})
         return published_date
 
     @property


### PR DESCRIPTION
This package is used on Home Assistant IGN Sismología Integration which supplies a wrong published_date field.